### PR TITLE
Fix Overlay bug

### DIFF
--- a/charts/azure-managed-cluster/Chart.yaml
+++ b/charts/azure-managed-cluster/Chart.yaml
@@ -5,5 +5,5 @@ type: application
 maintainers:
 - email: jt572@cornell.edu
   name: Jont828
-version: 0.2.3
+version: 0.2.4
 appVersion: 1.16.0

--- a/charts/azure-managed-cluster/values.yaml
+++ b/charts/azure-managed-cluster/values.yaml
@@ -48,7 +48,7 @@ controlplane:
 
   ## Network Plugin "kubenet" or "azure"
   networkPlugin: "azure"
-  networkPluginMode: "overlay"
+  networkPluginMode: "Overlay"
   sshPublicKey: ""
   outboundType: "loadBalancer"
   dnsServiceIP: ""


### PR DESCRIPTION
Fixes issue when trying to use default value:

```
Message:               managedcluster failed to create or update. err: failed to create resource default/aks0 (service: managedcluster): ManagedCluster.containerservice.azure.com "aks0" is invalid: spec.networkProfile.networkPluginMode: Unsupported value: "overlay": supported values: "Overlay"
```