### PR TITLE
fix: use all lowercase for authMode

### DIFF
--- a/charts/azure-aks-aso/Chart.yaml
+++ b/charts/azure-aks-aso/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: azure-aks-aso
 description: A chart describing an AKS cluster for CAPZ using the ASO API
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.1.0
 maintainers:
   - name: mboersma

--- a/charts/azure-aks-aso/values.yaml
+++ b/charts/azure-aks-aso/values.yaml
@@ -6,7 +6,7 @@ clientID: ""
 # Leave clientSecret blank if using WorkloadIdentity
 clientSecret: ""
 # Set to podIdentity for managed identity or service principal even if NOT using pod identity
-authMode: "workloadIdentity"
+authMode: "workloadidentity"
 
 # clusterName defaults to the name of the Helm release
 clusterName: ""


### PR DESCRIPTION
I'm seeing `encountered: authorization mode "workloadIdentity" not valid` from [here](https://github.com/Azure/azure-service-operator/blob/5f056f89a93b9ea16b5e9a96d17c290083f8aac6/v2/internal/identity/credential_provider.go#L352).

The constant in ASO is [workloadidentity](https://github.com/Azure/azure-service-operator/blob/5f056f89a93b9ea16b5e9a96d17c290083f8aac6/v2/pkg/common/config/scoped_credentials.go#L10) all in lowercase.