### PR TITLE
Deploy resources to given namespace

### DIFF
--- a/charts/azure-aks-aso/Chart.yaml
+++ b/charts/azure-aks-aso/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: azure-aks-aso
 description: A chart describing an AKS cluster for CAPZ using the ASO API
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: 0.1.0
 maintainers:
   - name: mboersma

--- a/charts/azure-aks-aso/templates/cluster.yaml
+++ b/charts/azure-aks-aso/templates/cluster.yaml
@@ -2,6 +2,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ include "capz.clusterName" . | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "capz.commonLabels" . | nindent 4 }}
 spec:
@@ -32,6 +33,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedCluster
 metadata:
   name: {{ include "capz.clusterName" . | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "capz.commonLabels" . | nindent 4 }}
   annotations:
@@ -43,6 +45,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedControlPlane
 metadata:
   name: {{ include "capz.clusterName" . | quote }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -53,6 +56,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: {{ printf "%s-%s" (include "capz.clusterName" $) $mpName | quote }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "capz.commonLabels" $ | nindent 4 }}
   annotations:
@@ -77,6 +81,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedMachinePool
 metadata:
   name: {{ printf "%s-%s" (include "capz.clusterName" $) $mpName | quote }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "capz.commonLabels" $ | nindent 4 }}
   annotations:

--- a/charts/azure-aks-aso/templates/clusterclass.yaml
+++ b/charts/azure-aks-aso/templates/clusterclass.yaml
@@ -3,6 +3,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
   name: {{ required "value clusterClassName must be set" .Values.clusterClassName | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "capz.commonLabels" . | nindent 4 }}
 spec:
@@ -81,6 +82,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedClusterTemplate
 metadata:
   name: {{ .Values.clusterClassName | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "capz.commonLabels" . | nindent 4 }}
   annotations:
@@ -93,6 +95,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedControlPlaneTemplate
 metadata:
   name: {{ .Values.clusterClassName | quote }}
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/resource-policy: keep
 spec:
@@ -103,6 +106,7 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: {{ .Values.clusterClassName | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   template:
     spec: {}
@@ -112,6 +116,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: AzureASOManagedMachinePoolTemplate
 metadata:
   name: {{ printf "%s-%s" $.Values.clusterClassName $mpName | quote }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "capz.commonLabels" $ | nindent 4 }}
   annotations:

--- a/charts/azure-aks-aso/templates/credentials.yaml
+++ b/charts/azure-aks-aso/templates/credentials.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.credentialSecretName | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "capz.commonLabels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
By specifying the `namespace` in the manifests they can't be deployed to the wrong namespace by accident. I found this useful when iterating locally.