### PR TITLE
Updated infrastructureRef and controlPlaneRef api version

### DIFF
--- a/charts/azure-aks-aso/Chart.yaml
+++ b/charts/azure-aks-aso/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: azure-aks-aso
 description: A chart describing an AKS cluster for CAPZ using the ASO API
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: 0.1.0
 maintainers:
   - name: mboersma

--- a/charts/azure-aks-aso/templates/cluster.yaml
+++ b/charts/azure-aks-aso/templates/cluster.yaml
@@ -21,15 +21,15 @@ spec:
       {{- end }}
 {{- else }}
   controlPlaneRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureASOManagedControlPlane
     name: {{ include "capz.clusterName" . | quote }}
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AzureASOManagedCluster
     name: {{ include "capz.clusterName" . | quote }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureASOManagedCluster
 metadata:
   name: {{ include "capz.clusterName" . | quote }}
@@ -41,7 +41,7 @@ metadata:
 spec:
   {{- include "capz.azureASOManagedClusterSpec" (list $ (include "capz.clusterName" $)) | nindent 2 }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureASOManagedControlPlane
 metadata:
   name: {{ include "capz.clusterName" . | quote }}
@@ -72,12 +72,12 @@ spec:
         dataSecretName: ""
       clusterName: {{ include "capz.clusterName" $ }}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureASOManagedMachinePool
         name: {{ printf "%s-%s" (include "capz.clusterName" $) $mpName | quote }}
       version: {{ default $.Values.kubernetesVersion $mp.orchestratorVersion | quote }}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureASOManagedMachinePool
 metadata:
   name: {{ printf "%s-%s" (include "capz.clusterName" $) $mpName | quote }}


### PR DESCRIPTION
I went thru the lab today and I noticed that ArgoCD didn't reconcile because of mismatch on what version get deployed by the helm chart and what is expected by the Application. The easiest way to fix was to fork the chart and update the version. I tested it and it works fine (built the chart on https://ams0.github.io/cluster-api-charts) and bumped the version.